### PR TITLE
Fix invalid syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 try:
     with open('README.md') as readme:
         long_description = readme.read()
-except IOError, ImportError:
+except IOError:
     long_description =''
 
 class PyTest(Command):


### PR DESCRIPTION
This code can't throw ImportError anyway

    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-6vcqlaw3-build/setup.py", line 12
        except IOError, ImportError:
                      ^
    SyntaxError: invalid syntax