### PR TITLE
Fixed decimals for seconds in demo output

### DIFF
--- a/videogrep/videogrep.py
+++ b/videogrep/videogrep.py
@@ -187,7 +187,7 @@ def demo_supercut(composition, padding):
         end = c['end']
         if i > 0 and composition[i - 1]['file'] == c['file'] and start < composition[i - 1]['end']:
             start = start + padding
-        print("{1} to {2}:\t{0}".format(line, start, end))
+        print("{1:.2f} to {2:.2f}:\t{0}".format(line, start, end))
 
 
 def create_supercut(composition, outputfile, padding):

--- a/videogrep/videogrep.py
+++ b/videogrep/videogrep.py
@@ -484,7 +484,7 @@ def videogrep(inputfile, outputfile, search, searchtype, maxclips=0, padding=0, 
                 split_clips(composition, outputfile)
             else:
                 if len(composition) > BATCH_SIZE:
-                    print("[+} Starting batch job.")
+                    print("[+] Starting batch job.")
                     create_supercut_in_batches(composition, outputfile, padding)
                 else:
                     create_supercut(composition, outputfile, padding)


### PR DESCRIPTION
Lines like 
```
3.7300000000000004 to 9.55:     Lorem ipsum dolor sit amet
```
are rather ugly and don't provide value to the user.


Bonus: Fixed the typo in `[+} Starting batch job.`