### PR TITLE
fix: Use pathlib to mitigate issues with Windows paths on local files

### DIFF
--- a/tests/test_videogrep.py
+++ b/tests/test_videogrep.py
@@ -2,6 +2,7 @@ import videogrep
 import os
 import re
 from collections import Counter
+from pathlib import Path
 from moviepy.editor import VideoFileClip
 from pytest import approx
 import glob
@@ -9,7 +10,7 @@ import subprocess
 
 
 def File(path):
-    return os.path.join(os.path.dirname(__file__), path)
+    return str(Path(__file__).parent / Path(path))
 
 
 def test_version():
@@ -208,7 +209,7 @@ def test_export_files():
         export_clips=True,
         output=out1,
     )
-    files = glob.glob(File("test_outputs/") + "supercut_clip*.mp4")
+    files = glob.glob(File("test_outputs/supercut_clip*.mp4"))
     assert len(files) == 4
     testfile = VideoFileClip(files[0])
     assert testfile.duration == approx(0.52)
@@ -382,7 +383,6 @@ def test_sentence_search_vtt():
 def test_cli():
     infile = File("test_inputs/manifesto.mp4")
     outfile = File("test_outputs/supercut.mp4")
-
     subprocess.run(
         [
             "poetry",
@@ -398,7 +398,8 @@ def test_cli():
             "fragment",
             "--max-clips",
             "1",
-        ]
+        ],
+        shell=True,
     )
 
     clip = VideoFileClip(outfile)

--- a/videogrep/videogrep.py
+++ b/videogrep/videogrep.py
@@ -5,6 +5,7 @@ import re
 import gc
 import time
 from . import vtt, srt, sphinx, fcpxml
+from pathlib import Path
 from typing import Optional, List, Union, Iterator
 
 from moviepy.editor import VideoFileClip, concatenate_videoclips
@@ -29,7 +30,7 @@ def find_transcript(videoname: str, prefer: Optional[str] = None) -> Optional[st
     if prefer is not None:
         _sub_exts = [prefer] + SUB_EXTS
 
-    all_files = [f.path for f in os.scandir(os.path.dirname(videoname)) if f.is_file()]
+    all_files = [str(f) for f in Path(videoname).parent.iterdir() if f.is_file()]
 
     for ext in _sub_exts:
         pattern = (


### PR DESCRIPTION
Fixes #109

This swaps out the os.path methods for using pathlib instead in the subtitle
detection function and test path generation. This helps mitigate Windows'
weird behaviour with dirname returns on files in the same directory.