### PR TITLE
Render search fragments as WebVTT file

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ Exports clips as individual files rather than as a supercut.
 videogrep -i vid.mp4 --search 'whatever' --export-clips
 ```
 
+#### `--export-vtt / -ev`
+
+Exports the transcript of the supercut as a WebVTT file next to the video.
+
+```
+videogrep -i vid.mp4 --search 'whatever' --export-vtt
+```
+
 #### `--ngrams [num] / -n [num]`
 
 Shows common words and phrases from the video.

--- a/videogrep/cli.py
+++ b/videogrep/cli.py
@@ -58,6 +58,13 @@ def main():
         help="show results without making the supercut",
     )
     parser.add_argument(
+        "--export-vtt",
+        "-ev",
+        dest="write_vtt",
+        action="store_true",
+        help="write a WebVTT file next to the supercut",
+    )
+    parser.add_argument(
         "--randomize", "-r", action="store_true", help="randomize the clips"
     )
     parser.add_argument(
@@ -154,4 +161,5 @@ def main():
         random_order=args.randomize,
         resync=args.sync,
         export_clips=args.export_clips,
+        write_vtt=args.write_vtt,
     )

--- a/videogrep/videogrep.py
+++ b/videogrep/videogrep.py
@@ -454,6 +454,7 @@ def videogrep(
     export_clips: bool = False,
     random_order: bool = False,
     demo: bool = False,
+    write_vtt: bool = False,
 ):
     """
     Creates a supercut of videos based on a search query
@@ -468,6 +469,7 @@ def videogrep(
     :param export_clips bool: Export individual clips rather than a single file (default False)
     :param random_order bool: Randomize the order of clips (default False)
     :param demo bool: Show the results of the search but don't actually make a supercut
+    :param write_vtt bool: Write a WebVTT file next to the supercut (default False)
     """
 
     segments = search(files, query, search_type)
@@ -520,5 +522,8 @@ def videogrep(
         create_supercut_in_batches(segments, output)
     else:
         create_supercut(segments, output)
-    basename, ext = os.path.splitext(output)
-    vtt.render(segments, basename + ".vtt")
+
+    # write WebVTT file
+    if write_vtt:
+        basename, ext = os.path.splitext(output)
+        vtt.render(segments, basename + ".vtt")

--- a/videogrep/videogrep.py
+++ b/videogrep/videogrep.py
@@ -520,3 +520,5 @@ def videogrep(
         create_supercut_in_batches(segments, output)
     else:
         create_supercut(segments, output)
+    basename, ext = os.path.splitext(output)
+    vtt.render(segments, basename + ".vtt")

--- a/videogrep/vtt.py
+++ b/videogrep/vtt.py
@@ -136,3 +136,22 @@ def convert_to_srt(sentence):
         out.append(sentence["text"])
         out.append("")
     return "\n".join(out)
+
+def render(segments: List[dict], outputfile: str):
+    """
+    Render a list of segments to a WebVTT file
+    
+    :param segments: List of segments as returned by videogrep.search
+    :param outputfile: Filename for the WebVTT output
+    """
+
+    start = 0.0
+    with open(outputfile, "w", encoding="utf-8") as outfile:
+        outfile.write("WEBVTT\n")
+        for index, s in enumerate(segments):
+            clip_duration = s["end"] - s["start"]
+            end = start + clip_duration
+            start_t = secs_to_timestamp(start)
+            end_t = secs_to_timestamp(end)
+            outfile.write(f"\n{index}\n{start_t} --> {end_t}\n{s['content']}\n")
+            start = end


### PR DESCRIPTION
It's not SRT, but otherwise this fixes #23.

Based on the algorithm for creating the correct timestamps in XML output, this uses the results from `videogrep.videogrep.search` to create a `.vtt` file using the same basename as the output filename.

To enable this export, users need to set the `--export-vtt` or `-ev` flag. This is evaluated after creating the supercut, so it won't work when other flags/options are used to do anything other than create a supercut.