### PR TITLE
Closing VideoFileClips after they are no longer needed

### DIFF
--- a/videogrep/videogrep.py
+++ b/videogrep/videogrep.py
@@ -419,6 +419,9 @@ def create_supercut(composition: List[dict], outputfile: str):
             remove_temp=True,
             audio_codec="aac",
         )
+
+        for clip in cut_clips:
+            clip.close()
     elif plan_audio_output(composition, outputfile):
         print("[+] Creating clips.")
         audiofileclips = dict([(f, AudioFileClip(f)) for f in all_filenames])


### PR DESCRIPTION
Fixed "OSError: [WinError 6] The handle is invalid" 
Aparently opening more than 5 clips without closing them again will cause file system errors 
Also see https://stackoverflow.com/a/60617556